### PR TITLE
#155 hotfix bug when generating model class names and path

### DIFF
--- a/internal/model/utils_test.go
+++ b/internal/model/utils_test.go
@@ -614,7 +614,7 @@ func TestModel_GetModelDirectorySuccess(t *testing.T) {
 	}
 
 	resultPath, err := model.GetModelDirectory()
-	expectedPath := "folder\\folder2\\models"
+	expectedPath := "folder/folder2/models"
 	test.AssertEqual(t, err, nil, "No error message")
 	test.AssertEqual(t, resultPath, expectedPath, "Path is as expected")
 }


### PR DESCRIPTION
Fixing a bug where some special characters make app crash, plus cases where the tokenizer path was being set incorrectly

closes #155 